### PR TITLE
split up converting to row and making row readable

### DIFF
--- a/src/Commands/ListSourcesCommand.php
+++ b/src/Commands/ListSourcesCommand.php
@@ -3,13 +3,13 @@
 namespace Spatie\BackupServer\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Spatie\BackupServer\Exceptions\InvalidCommandInput;
 use Spatie\BackupServer\Models\Backup;
 use Spatie\BackupServer\Models\Source;
 use Spatie\BackupServer\Support\AlignCenterTableStyle;
 use Spatie\BackupServer\Support\AlignRightTableStyle;
 use Spatie\BackupServer\Support\Helpers\Format;
-use Spatie\BackupServer\Tasks\Backup\Support\BackupCollection;
 
 class ListSourcesCommand extends Command
 {
@@ -36,9 +36,10 @@ class ListSourcesCommand extends Command
 
         $this->guardAgainstInvalidOptionValues($sortBy);
 
-        $rows = Source::get()
+        $rows = Source::all()
             ->map(fn (Source $source) => $this->convertToRow($source))
-            ->sortBy($sortBy, SORT_REGULAR, $this->option('desc'));
+            ->sortBy($sortBy, SORT_REGULAR, $this->option('desc'))
+            ->map(fn (Collection $data) => $this->makeRowReadable($data));
 
         $headers = array_values($this->headers);
 
@@ -60,36 +61,36 @@ class ListSourcesCommand extends Command
         $this->table($headers, $rows, 'default', $columnStyles);
     }
 
-    protected function convertToRow(Source $source): array
+    protected function makeRowReadable(Collection $row): array
     {
-        /** @var BackupCollection $completedBackups */
-        $completedBackups = $source->completedBackups;
+        return [
+            'name' => $row->get('name'),
+            'id' => $row->get('id'),
+            'healthy' => Format::emoji($row->get('healthy')),
+            'backup_count' => $row->get('backup_count'),
+            'newest_backup' => $row->get('newest_backup') ? Format::ageInDays($row->get('newest_backup')) : 'No backups present',
+            'youngest_backup_size' => $row->get('youngest_backup_size') ? Format::KbToHumanReadableSize($row->get('youngest_backup_size')) : '/',
+            'backup_size' => $row->get('backup_size') ? Format::KbToHumanReadableSize($row->get('backup_size')) : '/',
+            'used_storage' => $row->get('used_storage') ? Format::KbToHumanReadableSize($row->get('used_storage')) : '/',
+        ];
+    }
 
-        if ($source->completedBackups->isEmpty()) {
-            return [
-                'name' => $source->name,
-                'id' => $source->id,
-                'healthy' => Format::emoji(false),
-                'backup_count' => '0',
-                'newest_backup' => 'No backups present',
-                'youngest_backup_size' => '/',
-                'backup_size' => '/',
-                'used_storage' => '/',
-            ];
-        }
+    protected function convertToRow(Source $source): Collection
+    {
+        $completedBackups = $source->completedBackups;
 
         $youngestBackup = $completedBackups->youngest();
 
-        return [
+        return collect([
             'name' => $source->name,
             'id' => $source->id,
-            'health' => Format::emoji($source->isHealthy()),
+            'healthy' => $source->isHealthy(),
             'backup_count' => $completedBackups->count(),
-            'newest_backup' => Format::ageInDays($youngestBackup->created_at),
-            'youngest_backup_size' => Format::KbToHumanReadableSize($youngestBackup->size_in_kb),
-            'backup_size' => Format::KbToHumanReadableSize($completedBackups->sizeInKb()),
-            'real_used_storage' => Format::KbToHumanReadableSize($completedBackups->realSizeInKb()),
-        ];
+            'newest_backup' => $youngestBackup->created_at ?? null,
+            'youngest_backup_size' => $youngestBackup->size_in_kb ?? null,
+            'backup_size' => $completedBackups->sizeInKb(),
+            'real_used_storage' => $completedBackups->realSizeInKb(),
+        ]);
     }
 
     protected function getFormattedBackupDate(Backup $backup = null)


### PR DESCRIPTION
Sorting on  `youngest_backup_size `, `backup_size ` or `used_storage` does not work as expected. These values are converted to readable strings  (for example `4.01 GB` or `250.21 MB`) before we are sorting. 

To solve this, I've split this up into 3 parts:
- converting the sources into the needed collection
- ordering this collection
- reformatting the floats and integers to readable strings