### PR TITLE
Update creating-a-source.md to contain correct model

### DIFF
--- a/docs/taking-backups/creating-a-source.md
+++ b/docs/taking-backups/creating-a-source.md
@@ -9,7 +9,7 @@ The collection of files on a remote server that you wish to backup is represente
 A `Source` is an Eloquent model. It can be created like this.
 
 ```php
-Destinations\BackupServer\Models\Destination::create($attributes)
+Destinations\BackupServer\Models\Source::create($attributes)
 ```
 
 These attributes can be set


### PR DESCRIPTION
Docs incorrectly state to use
```
Destinations\BackupServer\Models\Destination::create($attributes)
```
to create a source.

Changed to:
```
Destinations\BackupServer\Models\Source::create($attributes)
```