### PR TITLE
Add multiple backup times

### DIFF
--- a/database/migrations/create_backup_server_tables.php.stub
+++ b/database/migrations/create_backup_server_tables.php.stub
@@ -43,7 +43,7 @@ class CreateBackupServerTables extends Migration
             $table->integer('ssh_port')->default(22);
             $table->string('ssh_private_key_file', 512)->nullable();
 
-            $table->integer('backup_hour')->default(0);
+            $table->string('backup_hour', 100)->default(0);
 
             $table->json('pre_backup_commands')->nullable();
             $table->json('post_backup_commands')->nullable();

--- a/docs/taking-backups/creating-a-source.md
+++ b/docs/taking-backups/creating-a-source.md
@@ -22,6 +22,12 @@ These attributes can be set
 - `destination_id`: the id of the [destination](/docs/laravel-backup-server/v1/taking-backups/creating-a-destination) you wish to backup to
 
 - `backup_hour`: the hour on which the `backup-server:dispatch-backups` should create a backup for this source
+    - `number` for a single backup run per day, e.g. `0`
+    - `*` to run every hour
+    - `semicolon-separated list` for defining multiple runs, e.g. `0;3;6;10`
+    - `timespans` to define a timespan in which a hourly backup is created, e.g. `6-22` or even `20-6`
+    - a combination of the above (except `*`), e.g. `0;5;10-20`
+
 
 - `includes`: an array of paths you wish to backup. These can be relative to the home directory of the ssh user, or absolute
 - `excludes`: an array of paths you wish to exclude from the backup. These should be relative to the paths giving in `includes`

--- a/src/Models/Source.php
+++ b/src/Models/Source.php
@@ -32,7 +32,6 @@ class Source extends Model
         'excludes' => 'array',
         'pre_backup_commands' => 'array',
         'post_backup_commands' => 'array',
-        'backup_hour' => 'integer',
     ];
 
     public static function booted()

--- a/src/Tasks/Backup/Support/BackupScheduler/DefaultBackupScheduler.php
+++ b/src/Tasks/Backup/Support/BackupScheduler/DefaultBackupScheduler.php
@@ -3,11 +3,54 @@
 namespace Spatie\BackupServer\Tasks\Backup\Support\BackupScheduler;
 
 use Spatie\BackupServer\Models\Source;
+use Illuminate\Support\Str;
 
 class DefaultBackupScheduler implements BackupScheduler
 {
     public function shouldBackupNow(Source $source): bool
     {
-        return now()->hour === $source->backup_hour;
+        // Backup every hour
+        if ($source->backup_hour === '*') {
+            return true;
+        }
+
+        $currentHour = now()->hour;
+
+        // Backup one specific hour: [0-23]
+        if (is_numeric($source->backup_hour)) {
+            return $currentHour === (int) $source->backup_hour;
+        }
+
+        // Backup multiple hours: e.g. 0;1;5;10;13-17
+        $hours = explode(';', $source->backup_hour);
+        foreach ($hours as $hour) {
+            // Backup one specific hour: [0-23]
+            if (is_numeric($hour) && $currentHour === (int) $hour) {
+                return true;
+            }
+
+            // Backup in timespan
+            if (Str::contains($hour, '-')) {
+                $bounds = explode('-', $hour);
+
+                $leftBound = (int) $bounds[0];
+                $rightBound = (int) $bounds[1];
+
+                // If someone would note something link 22-5
+                if ($leftBound > $rightBound) {
+                    if ($currentHour >= $leftBound || $currentHour <= $rightBound) {
+                        return true;
+                    }
+                } else {
+                    // This would match something like 5-23
+                    if ($currentHour >= $leftBound && $currentHour <= $rightBound) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // Fallback
+        return false;
     }
 }

--- a/tests/Feature/Tasks/Backup/Support/ScheduleBackupTest.php
+++ b/tests/Feature/Tasks/Backup/Support/ScheduleBackupTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Spatie\BackupServer\Tests\Feature\Tasks\Backup\Support;
+
+use Carbon\Carbon;
+use Spatie\BackupServer\Models\Source;
+use Spatie\BackupServer\Tasks\Backup\Support\BackupScheduler\BackupScheduler;
+use Spatie\BackupServer\Tests\TestCase;
+
+class ScheduleBackupTest extends TestCase {
+
+    private ?Source $source1;
+    private ?Source $source2;
+    private ?Source $source3;
+    private ?Source $source4;
+    private ?Source $source5;
+
+    private BackupScheduler $backupScheduler;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->backupScheduler = app(BackupScheduler::class);
+
+        $this->source1 = Source::factory()->create([
+                                                       'host'                 => '0.0.0.0',
+                                                       'ssh_port'             => '4848',
+                                                       'ssh_user'             => 'root',
+                                                       'ssh_private_key_file' => '',
+                                                       'includes'             => ['/src'],
+                                                       'excludes'             => ['exclude.txt'],
+                                                       'backup_hour'          => now()->hour,
+                                                   ]);
+
+        $this->source2 = Source::factory()->create([
+                                                       'host'                 => '0.0.0.0',
+                                                       'ssh_port'             => '4848',
+                                                       'ssh_user'             => 'root',
+                                                       'ssh_private_key_file' => '',
+                                                       'includes'             => ['/src'],
+                                                       'excludes'             => ['exclude.txt'],
+                                                       'backup_hour'          => '*',
+                                                   ]);
+
+        $this->source3 = Source::factory()->create([
+                                                       'host'                 => '0.0.0.0',
+                                                       'ssh_port'             => '4848',
+                                                       'ssh_user'             => 'root',
+                                                       'ssh_private_key_file' => '',
+                                                       'includes'             => ['/src'],
+                                                       'excludes'             => ['exclude.txt'],
+                                                       'backup_hour'          => '0;2;5;10',
+                                                   ]);
+
+        $this->source4 = Source::factory()->create([
+                                                       'host'                 => '0.0.0.0',
+                                                       'ssh_port'             => '4848',
+                                                       'ssh_user'             => 'root',
+                                                       'ssh_private_key_file' => '',
+                                                       'includes'             => ['/src'],
+                                                       'excludes'             => ['exclude.txt'],
+                                                       'backup_hour'          => '10-20',
+                                                   ]);
+
+        $this->source5 = Source::factory()->create([
+                                                       'host'                 => '0.0.0.0',
+                                                       'ssh_port'             => '4848',
+                                                       'ssh_user'             => 'root',
+                                                       'ssh_private_key_file' => '',
+                                                       'includes'             => ['/src'],
+                                                       'excludes'             => ['exclude.txt'],
+                                                       'backup_hour'          => '3;8-14;16;20-23',
+                                                   ]);
+    }
+
+    /** @test */
+    public function it_will_run_a_single_backup_per_day()
+    {
+        Carbon::setTestNow();
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source1));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(Carbon::now()->hour + 1));
+        $this->assertFalse($this->backupScheduler->shouldBackupNow($this->source1));
+    }
+
+    /** @test */
+    public function it_will_run_hourly_per_day()
+    {
+        Carbon::setTestNow();
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source2));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(Carbon::now()->hour + 3));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source2));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(Carbon::now()->hour - 5));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source2));
+    }
+
+    /** @test */
+    public function it_will_run_multiple_times_per_day()
+    {
+        // Fake Date now to one of the desired times
+        Carbon::setTestNow(Carbon::now()->setHour(5));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source3));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(6));
+        $this->assertFalse($this->backupScheduler->shouldBackupNow($this->source3));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(10));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source3));
+    }
+
+    /** @test */
+    public function it_will_run_in_a_given_timespan_per_day()
+    {
+        // Fake Date now to one of the desired times
+        Carbon::setTestNow(Carbon::now()->setHour(10));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source4));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(6));
+        $this->assertFalse($this->backupScheduler->shouldBackupNow($this->source4));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(16));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source4));
+    }
+
+    /** @test */
+    public function it_will_run_on_different_times_per_day()
+    {
+        // Fake Date now to one of the desired times
+        Carbon::setTestNow(Carbon::now()->setHour(3));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source5));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(13));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source5));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(15));
+        $this->assertFalse($this->backupScheduler->shouldBackupNow($this->source5));
+
+        // Fake Date now to another time
+        Carbon::setTestNow(Carbon::now()->setHour(21));
+        $this->assertTrue($this->backupScheduler->shouldBackupNow($this->source5));
+    }
+}


### PR DESCRIPTION
Added a modification to allow multiple backups per day
- single times, e.g. 0
- hourly backups: *
- multiple times, e.g. 4;8;23
- timespans, e.g. 3-9
- combinations, e.g. 3;6-9;20

Fixes #14 