### PR TITLE
Increase disk usage command timeout

### DIFF
--- a/src/Tasks/Backup/Support/BackupCollection.php
+++ b/src/Tasks/Backup/Support/BackupCollection.php
@@ -45,7 +45,7 @@ class BackupCollection extends Collection
 
         $command = 'du -kd 1 ..';
 
-        // `du` on EBS volumes isn't too fast. 5 minutes should be enough for a 150GB backup
+        // `du` on EBS volumes isn't too fast, so we'll give it some extra time
         $timeout = 60 * 15;
 
         $process = Process::fromShellCommandline($command, $firstBackup->destinationLocation()->getFullPath())


### PR DESCRIPTION
While running the task `RecalculateRealBackupSizes` a timeout is thrown for a project with a significant amount of files.

```
Backup Server APP  ...
Clean up failed!
An error occurred while cleaning up the backups of ....
Destination
...
Exception message
The process "du -kd 1 .." exceeded the timeout of 300 seconds.
```

Increasing the timeout to 15 minutes should be enough to successfully perform the disk usage command.

Alternatively I could make that value configurable in the config.