### PR TITLE
Fixed queue_connection key

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -187,7 +187,7 @@ In the backup server configuration you must set the `queue_connection` to `backu
 ```php
 // in config/backup-server.php
 
-'connection' => 'backup-server-redis',
+'queue_connection' => 'backup-server-redis',
 ```
 
 In the Horizon config you can add extra configuration for backup server.


### PR DESCRIPTION
Inside the config/backup-server.php the key for the connection has to be `queue_connection` instead of `connection`.