### PR TITLE
Fix empty path error for Backup model

### DIFF
--- a/src/Models/Backup.php
+++ b/src/Models/Backup.php
@@ -54,7 +54,7 @@ class Backup extends Model
     public static function booted()
     {
         static::deleting(function (Backup $backup) {
-            if ($backup->disk()->exists($backup->path)) {
+            if (!empty($backup->path) && $backup->disk()->exists($backup->path)) {
                 $backup->disk()->deleteDirectory($backup->path);
             }
         });


### PR DESCRIPTION
Hello,

here are steps to reproduce the error:

1. On the remote side, in the backup path I have a `.env` file with contains the string `DB_PASSWORD=xxx(xxx"
2. On pre backup script, I am sourcing this file (Linux source command). As I have not wrapped the password in quotes, it gives me error: `syntax error near unexpected token `('` (Pre backup bash script)
3. On the backup server's side, a backup is created in the database with a `path` having null.
4. If I delete this failed backup, I got: `Argument #1 ($location) must be of type string, null given`
5. The result is there is no possible way to delete the backup + daily checks fail to delete backups

This is correct behavior, as `$backup->disk()->exists($backup->path)` awaits string. I have added null checking in if statement to prevent error.