### PR TITLE
Refactor status() method for clarity and better inheritance support

### DIFF
--- a/src/Models/Concerns/HasAsyncDelete.php
+++ b/src/Models/Concerns/HasAsyncDelete.php
@@ -33,7 +33,9 @@ trait HasAsyncDelete
             Source::class => SourceStatus::Deleting,
             Destination::class => DestinationStatus::Deleting,
             Backup::class => BackupStatus::Deleting,
-            default => throw new \Exception('Unknown class type'),
+            default => throw new \InvalidArgumentException(
+                'Unknown class type for deletion status: '.static::class
+            ),
         };
     }
 }

--- a/src/Models/Concerns/HasAsyncDelete.php
+++ b/src/Models/Concerns/HasAsyncDelete.php
@@ -13,7 +13,7 @@ trait HasAsyncDelete
 {
     public function asyncDelete(): void
     {
-        $this->update(['status' => $this->status($this)]);
+        $this->update(['status' => $this->status()]);
 
         $deletionJobClassName = $this->getDeletionJobClassName();
 
@@ -22,14 +22,14 @@ trait HasAsyncDelete
 
     public function willBeDeleted(): bool
     {
-        return $this->status === $this->status($this);
+        return $this->status === $this->status();
     }
 
     abstract public function getDeletionJobClassName(): string;
 
-    protected function status(self $class): DestinationStatus|BackupStatus|SourceStatus
+    protected function status(): DestinationStatus|BackupStatus|SourceStatus
     {
-        return match ($class::class) {
+        return match (static::class) {
             Source::class => SourceStatus::Deleting,
             Destination::class => DestinationStatus::Deleting,
             Backup::class => BackupStatus::Deleting,


### PR DESCRIPTION
This PR introduces two small but meaningful improvements to the HasAsyncDelete trait:

Use static::class instead of instance class check

The status() method now relies on static::class, improving compatibility with inheritance and removing the unnecessary $class parameter.

Replace generic Exception with InvalidArgumentException

Enhances clarity by throwing a more appropriate exception type when an unknown class is encountered in the match statement.