### PR TITLE
Fix --progress flag in rsync command

### DIFF
--- a/src/Tasks/Backup/Jobs/BackupTasks/RunBackup.php
+++ b/src/Tasks/Backup/Jobs/BackupTasks/RunBackup.php
@@ -78,7 +78,7 @@ class RunBackup implements BackupTask
             ->implode(' ');
 
         // --info=progress2
-        return "rsync -progress -zaHLK --stats  {$excludes} {$linkFromDestination} -e \"ssh {$privateKeyFile} -p {$port}\" {$source} {$destination}";
+        return "rsync --progress -zaHLK --stats  {$excludes} {$linkFromDestination} -e \"ssh {$privateKeyFile} -p {$port}\" {$source} {$destination}";
     }
 
     protected function saveRsyncSummary(Backup $backup, string $output)


### PR DESCRIPTION
this PR will fix an incorrect `-progress` flag in rsync command, that prevents to trigger the transfer speed update

this will fix #61 as well